### PR TITLE
Update list names to use hyphens

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,29 +19,42 @@ At the top level, additional supplementary data can be added. However, currently
 Repeating items are any bits of data that have the same semantic structure but contain different data. For example, a list of employees, companies, products etc.
 This is used to support repeating/looping features in eQ Runner. `items` are used as `lists` in runner, therefore `items` allow you to use any `list` feature in eQ Runner such as Looping and Repeating sections.
 
-Each top-level property of `items` is considered a `list`. Each property will represent a list in eQ Runner. For example, `items.employees` will be a list of employees. 
+Each top-level property of `items` is considered a `list`. Each property will represent a list in eQ Runner. For example, `items.employees` will be a list of employees.
+
+*Note: The name of `items` is restricted to lowercase alphanumeric characters and hyphens. This is because the name of `items` is used in the URL of eQ Runner. Therefore, this restriction is required to ensure URLs are accessible and follow gov.uk guidelines.*
 
 Items must follow this spec:
 
 ```json
 {
-	"<some-name>": {
-		"type": "array",
-		"minItems": 1,
-		"uniqueItems": true,
-		"items": {
-			"type": "object",
-			"properties": {
-				"identifier": {
-					"type": ["string", "integer"],
-					"minLength": 1,
-					"minimum": 0,
-					"description": "The unique identifier for the item"
+	"items": {
+		"type": "object",
+		"propertyNames": {
+			"pattern": "^[a-z0-9][a-z0-9\\-]*[a-z0-9]$",
+			"description": "Names for repeating items must be lower case, start with a letter or number, end with a letter or number, and contain only letters, numbers, or hyphens. This field can be shown in eQ URLs therefore no other characters are allowed."
+		},
+		"properties": {
+			"<some-name>": {
+				"type": "array",
+				"minItems": 1,
+				"uniqueItems": true,
+				"items": {
+					"type": "object",
+					"properties": {
+						"identifier": {
+							"type": ["string", "integer"],
+							"minLength": 1,
+							"minimum": 0,
+							"description": "The unique identifier for the item"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["identifier"]
 				}
-			},
-			"additionalProperties": false,
-			"required": ["identifier"]
-		}
+			}
+		},
+		"additionalProperties": false,
+		"required": ["<some-name>"]
 	}
 }
 ```

--- a/docs/bres_and_brs.md
+++ b/docs/bres_and_brs.md
@@ -18,12 +18,12 @@ Schema: [bres_and_brs.json](/schemas/bres_and_brs.json)
 | `employer_paye.tax_office_number`          | The 3 digit tax office number for the PAYE reference.                                                           | Yes       |
 | `employer_paye.reference`                  | The tax office employer reference for the PAYE reference.                                                       | Yes       |
 | `address`                                  | An array containing fields of the address for the reporting unit. At least 2 address lines and Postcode.        | Yes       |
-| `items.local_units`                        | Data about the local units                                                                                      | Yes       |
-| `items.local_units[].identifier`           | The identifier for the local unit. This is a string representing the local unit reference.                      | Yes       |
-| `items.local_units[].name`                 | The name of the local unit.                                                                                     | Yes       |
-| `items.local_units[].trading_name`         | The "trading as" name for the local unit.                                                                       | No        |
-| `items.local_units[].business_description` | The business description for the local unit.                                                                    | Yes       |
-| `items.local_units[].address`              | An array containing fields of the address for the local unit. At least 1 address line and Postcode will exist.  | Yes       |
+| `items.local-units`                        | Data about the local units                                                                                      | Yes       |
+| `items.local-units[].identifier`           | The identifier for the local unit. This is a string representing the local unit reference.                      | Yes       |
+| `items.local-units[].name`                 | The name of the local unit.                                                                                     | Yes       |
+| `items.local-units[].trading_name`         | The "trading as" name for the local unit.                                                                       | No        |
+| `items.local-units[].business_description` | The business description for the local unit.                                                                    | Yes       |
+| `items.local-units[].address`              | An array containing fields of the address for the local unit. At least 1 address line and Postcode will exist.  | Yes       |
 
 ## Examples
 

--- a/docs/roofing_tiles_slate_sand_and_gravel.md
+++ b/docs/roofing_tiles_slate_sand_and_gravel.md
@@ -10,10 +10,10 @@ Schema: [roofing_tiles_slate_sand_and_gravel.json](/schemas/roofing_tiles_slate_
 
 | Path                             | Description                                                                                | Mandatory |
 |----------------------------------|--------------------------------------------------------------------------------------------|-----------|
-| `items.local_units`              | Data about the local units                                                                 | Yes       |
-| `items.local_units[].identifier` | The identifier for the local unit. This is a string representing the local unit reference. | Yes       |
-| `items.local_units[].name`       | A string representing the name of the local unit.                                          | Yes       |
-| `items.local_units[].address`    | An array containing fields of the address for the local unit.                              | Yes       |
+| `items.local-units`              | Data about the local units                                                                 | Yes       |
+| `items.local-units[].identifier` | The identifier for the local unit. This is a string representing the local unit reference. | Yes       |
+| `items.local-units[].name`       | A string representing the name of the local unit.                                          | Yes       |
+| `items.local-units[].address`    | An array containing fields of the address for the local unit.                              | Yes       |
 
 ## Examples
 

--- a/examples/bres_and_brs/v1.json
+++ b/examples/bres_and_brs/v1.json
@@ -18,7 +18,7 @@
     "GL4 5YU"
   ],
   "items": {
-    "local_units": [
+    "local-units": [
       {
         "identifier": "3340224",
         "name": "STUBBS BUILDING PRODUCTS LTD",

--- a/examples/roofing_tiles_slate_sand_and_gravel/v1.json
+++ b/examples/roofing_tiles_slate_sand_and_gravel/v1.json
@@ -2,7 +2,7 @@
   "schema_version": "v1",
   "identifier": "50000035606",
   "items": {
-    "local_units": [
+    "local-units": [
       {
         "identifier": "3340224",
         "name": "STUBBS BUILDING PRODUCTS LTD",

--- a/schemas/bres_and_brs.json
+++ b/schemas/bres_and_brs.json
@@ -85,8 +85,11 @@
     },
     "items": {
       "type": "object",
+      "propertyNames": {
+        "pattern": "^[a-z0-9][a-z0-9\\-]*[a-z0-9]$"
+      },
       "properties": {
-        "local_units": {
+        "local-units": {
           "type": "array",
           "description": "The data about each item",
           "minItems": 1,
@@ -150,7 +153,7 @@
         }
       },
       "additionalProperties": false,
-      "required": ["local_units"]
+      "required": ["local-units"]
     }
   },
   "additionalProperties": false,

--- a/schemas/prodcom.json
+++ b/schemas/prodcom.json
@@ -38,6 +38,9 @@
     },
     "items": {
       "type": "object",
+      "propertyNames": {
+        "pattern": "^[a-z0-9][a-z0-9\\-]*[a-z0-9]$"
+      },
       "properties": {
         "products": {
           "type": "array",

--- a/schemas/roofing_tiles_slate_sand_and_gravel.json
+++ b/schemas/roofing_tiles_slate_sand_and_gravel.json
@@ -17,8 +17,11 @@
     },
     "items": {
       "type": "object",
+      "propertyNames": {
+        "pattern": "^[a-z0-9][a-z0-9\\-]*[a-z0-9]$"
+      },
       "properties": {
-        "local_units": {
+        "local-units": {
           "type": "array",
           "description": "The data about each item",
           "minItems": 1,
@@ -65,7 +68,7 @@
         }
       },
       "additionalProperties": false,
-      "required": ["local_units"]
+      "required": ["local-units"]
     }
   },
   "additionalProperties": false,

--- a/schemas/template_v1.json
+++ b/schemas/template_v1.json
@@ -17,6 +17,10 @@
     },
     "items": {
       "type": "object",
+      "propertyNames": {
+        "pattern": "^[a-z0-9][a-z0-9\\-]*[a-z0-9]$",
+        "description": "Names for repeating items must be lower case, start with a letter or number, end with a letter or number, and contain only letters, numbers, or hyphens. This field can be shown in eQ URLs therefore no other characters are allowed."
+      },
       "properties": {
         "<some-name>": {
           "type": "array",


### PR DESCRIPTION
### What is the context of this PR?
Enforces "items" name must be lower case alphanumeric and that it must only contain hyphens. Currently, underscores and uppercase are allowed, which reduces accessibility since they are displayed in eQ URLs and break gov.uk guidelines.

### Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->

### Checklist

* [x] Changes to the spec have been added to example schemas in [examples/](/examples/)
* [x] JSON Schema definitions have been updated
